### PR TITLE
#9 Add the *new* argument

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,13 +1,14 @@
 {
+  "name": "new",
   "version": "1.0.0",
-  "description": "m",
-  "main": "m",
+  "description": "documan management system",
+  "main": "index.js",
   "scripts": {
     "test": ""
   },
   "keywords": [],
-  "author": "a",
-  "license": "I",
+  "author": "Inumidun",
+  "license": "ISC",
   "dependencies": {
     "axios": "^0.16.2",
     "babel-cli": "^6.24.1",

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const ReactRaise = require('./lib/ReactRaise');
 const speak = require('./lib/speak');
+const argv = require('minimist')(process.argv.slice(2));
 
 speak('React Raise', 'figlet');
 speak(
@@ -8,4 +9,15 @@ speak(
 
 const app = new ReactRaise();
 
-app.init();
+switch (argv._[0]) {
+  case 'new':
+    return (argv._[1] && argv._[1].length > 1) ?
+      app.init(argv._[1]) :
+      speak('ERROR: Invalid react app name', 'console', 'red');
+  default:
+    speak(
+      `ERROR: Argument '${argv._[0]}' is not a valid argument. Use 'new' instead`,
+      'console',
+      'red'
+      );
+}

--- a/lib/ReactRaise.js
+++ b/lib/ReactRaise.js
@@ -45,12 +45,13 @@ class ReactRaise {
 
   /**
    * initialize command and ask setup questions
+   * @param {String} name - name of react app to create
    * @param {Function} callback - function to execute after answers
    * has been given
    * @returns {Void} returns nothing
    * @memberOf ReactRaise
    */
-  init(callback) {
+  init(name, callback) {
     const configGenerate = new Generate();
     const fileStructure = new Structure();
     const startInquire = new Inquire();
@@ -83,7 +84,7 @@ class ReactRaise {
       if (callback) {
         callback();
       }
-      configGenerate.all(answers);
+      configGenerate.all(Object.assign({}, answers, { name }));
       fileStructure.build();
     });
   }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "inquirer": "^3.1.0",
     "jsonfile": "^3.0.0",
     "lodash": "^4.17.4",
+    "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "touch": "^1.0.0"
   }

--- a/test/lib/reactraise.spec.js
+++ b/test/lib/reactraise.spec.js
@@ -15,7 +15,7 @@ describe('Index', () => {
     it('should start the commnd with a set of questions', (done) => {
        const currentProps  = Object.assign({}, reactRaise.privateProps);
        bddStdin('m','\n', 'm', '\n', 'a', '\n', 'I', '\n', 'y', '\n');
-       reactRaise.init(() => {
+       reactRaise.init('name', () => {
         expect(currentProps).to.not.eql(reactRaise.privateProps);
         done();
       });


### PR DESCRIPTION
#### What Does This PR Do?
This PR adds *new* argument and parses its resulting value

#### Description Of Task To Be Completed
The *new* argument is added, which tells react-raise to create a new react application.
If anything other than `new` is typed then the system throws an error saying
`ERROR: Argument 'wring' is not a valid argument. Use 'new' instead`
User can now pass in the app's name as the second value
If the app name is not supplied or it is an empty string then the system will output the following error: `ERROR: Invalid react app name`

#### Any Background Context You Want To Provide?
N/A

#### How can this be manually tested?
- clone this repo `git clone https://github.com/andela-iamao/react-raise.git`
- navigate to cloned repo `cd react-raise`
- install dependencies `npm install`
- Run tests `npm test`
- Start command `node index.js new appname`

#### Screenshot(s)
![image](https://user-images.githubusercontent.com/25608320/27086847-599c9c70-504b-11e7-8f64-37bd8c8344cb.png)

#### What are the relevant github issues?
#9 